### PR TITLE
Bump hc-releases to 0.11.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ jobs:
 | Input              | Description                                               | Default                |
 | ------------------ | --------------------------------------------------------- | ---------------------- |
 | `github-token`     | GitHub token with release asset access to `hc-releases`.  |                        |
-| `version`          | Version of `hc-releases` to install.                      | `0.11.6`               |
-| `version-checksum` | Platform and version checksum of `hc-releases` to verify. | Automatic for `0.11.6` |
+| `version`          | Version of `hc-releases` to install.                      | `0.11.7`               |
+| `version-checksum` | Platform and version checksum of `hc-releases` to verify. | Automatic for `0.11.7` |
 
 ### Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -13,7 +13,7 @@ inputs:
   version:
     description: "Version of hc-releases to install."
     required: false
-    default: "0.11.6"
+    default: "0.11.7"
   version-checksum:
     description: "Platform and version checksum of hc-releases to verify."
     required: false

--- a/dist/index.js
+++ b/dist/index.js
@@ -207,6 +207,17 @@ const checksums = {
       'amd64': '454e88864a459524f598e9e2b13d12afb3dfbd40691c60b685d59f7c74478f54'
     }
   },
+  '0.11.7': {
+    'darwin': {
+      'amd64': '096ba7ee269efd5215a378b9f0f04ade7ada1a8ffda836fd91171ed8a2e8d6e9'
+    },
+    'linux': {
+      'amd64': '75add216e9e89e11f2aaeb48bba9c3adaad7a01cdb2469fd900534413b178400'
+    },
+    'windows': {
+      'amd64': '3e7f3e12bb7fc0fadb62e75187eff70c36dfb70b50e29e8b78dbdd78a2ad90ce'
+    }
+  },
 };
 const executableName = 'hc-releases';
 const gitHubRepositoryOwner = 'hashicorp';

--- a/hc-releases.js
+++ b/hc-releases.js
@@ -55,6 +55,17 @@ const checksums = {
       'amd64': '454e88864a459524f598e9e2b13d12afb3dfbd40691c60b685d59f7c74478f54'
     }
   },
+  '0.11.7': {
+    'darwin': {
+      'amd64': '096ba7ee269efd5215a378b9f0f04ade7ada1a8ffda836fd91171ed8a2e8d6e9'
+    },
+    'linux': {
+      'amd64': '75add216e9e89e11f2aaeb48bba9c3adaad7a01cdb2469fd900534413b178400'
+    },
+    'windows': {
+      'amd64': '3e7f3e12bb7fc0fadb62e75187eff70c36dfb70b50e29e8b78dbdd78a2ad90ce'
+    }
+  },
 };
 const executableName = 'hc-releases';
 const gitHubRepositoryOwner = 'hashicorp';


### PR DESCRIPTION
Similar to https://github.com/hashicorp/setup-hc-releases/pull/75, this PR makes hc-releases v0.11.7 available via setup-hc-releases, and sets the default version to 0.11.7. 