### PR TITLE
RELENG-3: update test suite

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,4 +12,12 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - run: npm ci
-    - run: npm test
+    - name: npm mock tests
+      run: npm run test -- --testPathIgnorePatterns hc-releases.live.test.js
+
+    # only use the live auth token for the tests that require it
+    - name: npm live tests
+      env:
+        GITHUB_TOKEN: ${{ secrets.TOKEN_DOWNLOAD_RELAPI }}
+      run: |
+        npm test hc-releases.live.test.js

--- a/README.md
+++ b/README.md
@@ -66,8 +66,9 @@ npm run prepare
 2. Run `npm install`
 3. Update the [README](https://github.com/hashicorp/setup-hc-releases/blob/main/README.md) to reflect the new default of `hc-releases` version to install.
 4. Update [the version](https://github.com/hashicorp/setup-hc-releases/blob/main/action.yml#L16) in `action.yml` to reflect the new default version of `hc-releases` to install.
-5. Download the [SHASUMS file](https://github.com/hashicorp/releases-api/releases) from the new version of `hc-releases`
-6. Add a new object under `const checkSums = {` in `hc-releases.js` with the checksums for the new version, e.g.
+5. Update [latestVersion](https://github.com/hashicorp/setup-hc-releases/blob/main/hc-releases.js#L137) in `hc-releases.js` to reflect the new version.
+6. Download the [SHASUMS file](https://github.com/hashicorp/releases-api/releases) from the new version of `hc-releases`
+7. Add a new object under `const checksums = {` in `hc-releases.js` with the checksums for the new version, e.g.
 
 ```
   '0.1.2': {
@@ -81,10 +82,10 @@ npm run prepare
   },
 ```
 
-7. Run `npm run prepare`. This will update `dist/index.js` and `dist/index.js.map` with the new version's checksums.
-8. Run tests locally to verify they are passing with `npm run test`. If they're failing, fix the tests.
-9. Commit your changes, open a PR, get it reviewed, and merge to `main`.
-10. Checkout the `main` branch and pull down latest changes.
-11. Create a new tag for the release, e.g. `v2.0.1` with `git tag v2.0.1 && git push origin v2.0.1`.
-12. Delete the major version tag, e.g. `git tag -d v2 && git push origin :refs/tags/v2`
-13. Create a new major version tag, e.g. `git tag v2 && git push origin v2`
+8. Run `npm run prepare`. This will update `dist/index.js` and `dist/index.js.map` with the new version's checksums.
+9. Run tests locally to verify they are passing with `npm run test`. If they're failing, fix the tests.  **Note:** the live tests require a valid GITHUB_TOKEN set in your environment.
+10. Commit your changes, open a PR, get it reviewed, and merge to `main`.
+11. Checkout the `main` branch and pull down latest changes.
+12. Create a new tag for the release, e.g. `v2.0.1` with `git tag v2.0.1 && git push origin v2.0.1`.
+13. Delete the major version tag, e.g. `git tag -d v2 && git push origin :refs/tags/v2`
+14. Create a new major version tag, e.g. `git tag v2 && git push origin v2`

--- a/action.test.js
+++ b/action.test.js
@@ -5,24 +5,27 @@ const os = require('os');
 
 const exec = require("@actions/exec");
 
+const { latestVersion } = require('./hc-releases');
+const configuredVersion = '0.1.2';
+
 const mockDataChecksum = '5663389ef1a8ec48af6ca622e66bf0f54ba8f22c127f14cb8a3f429e40868582';
-const mockRelease = {
+const mockReleaseVersion = {
   assets: [
-    {
-      id: 1,
-      name: "hc-releases_0.1.2_linux_amd64.zip"
-    },
-    {
-      id: 2,
-      name: "hc-releases_0.1.2_darwin_amd64.zip"
-    },
-    {
-      id: 3,
-      name: "hc-releases_0.1.2_darwin_arm64.zip"
-    },
+    { id: 1, name: "hc-releases_"+configuredVersion+"_linux_amd64.zip" },
+    { id: 2, name: "hc-releases_"+configuredVersion+"_darwin_amd64.zip" },
+    { id: 3, name: "hc-releases_"+configuredVersion+"_darwin_arm64.zip" },
   ],
   id: "1",
-  name: "v0.1.2",
+  name: configuredVersion,
+};
+const mockRelease = {
+  assets: [
+    { id: 1, name: "hc-releases_"+latestVersion+"_linux_amd64.zip" },
+    { id: 2, name: "hc-releases_"+latestVersion+"_darwin_amd64.zip" },
+    { id: 3, name: "hc-releases_"+latestVersion+"_darwin_arm64.zip" },
+  ],
+  id: "1",
+  name: latestVersion,
 };
 const token = 'testtoken'
 
@@ -30,30 +33,30 @@ beforeAll(() => {
   nock.disableNetConnect();
 });
 
-beforeEach(() => {
-  process.env['INPUT_GITHUB-TOKEN'] = token;
-  delete process.env['INPUT_VERSION'];
-  process.env['INPUT_VERSION-CHECKSUM'] = mockDataChecksum;
-  //process.env['RUNNER_DEBUG'] = true;
-
-  const spyExecExec = jest.spyOn(exec, 'exec');
-  spyExecExec.mockImplementation((commandLine, args, options) => {
-    if (commandLine === 'hc-releases' && args.length === 1 && args[0] === 'version' && options !== undefined && options.listeners !== undefined) {
-      options.listeners.stdout('0.1.2');
-    }
-
-    Promise.resolve();
-  });
-  const spyOsArch = jest.spyOn(os, 'arch');
-  spyOsArch.mockReturnValue('x64');
-  const spyOsPlatform = jest.spyOn(os, 'platform');
-  spyOsPlatform.mockReturnValue('linux');
-});
-
 describe('action', () => {
+  beforeEach(() => {
+    process.env['INPUT_GITHUB-TOKEN'] = token;
+    delete process.env['INPUT_VERSION'];
+    process.env['INPUT_VERSION-CHECKSUM'] = mockDataChecksum;
+    //process.env['RUNNER_DEBUG'] = true;
+
+    const spyExecExec = jest.spyOn(exec, 'exec');
+    spyExecExec.mockImplementation((commandLine, args, options) => {
+      if (commandLine === 'hc-releases' && args.length === 1 && args[0] === 'version' && options !== undefined && options.listeners !== undefined) {
+        options.listeners.stdout(latestVersion);
+      }
+
+      Promise.resolve();
+    });
+    const spyOsArch = jest.spyOn(os, 'arch');
+    spyOsArch.mockReturnValue('x64');
+    const spyOsPlatform = jest.spyOn(os, 'platform');
+    spyOsPlatform.mockReturnValue('linux');
+  });
+
   test('installs default version', (done) => {
     const scope = nock('https://api.github.com')
-      .get('/repos/hashicorp/releases-api/releases/tags/v0.1.2')
+      .get('/repos/hashicorp/releases-api/releases/tags/v'+latestVersion)
       .reply(200, mockRelease)
       .get('/repos/hashicorp/releases-api/releases/assets/1')
       .replyWithFile(200, path.resolve(__dirname, 'test.zip'), { 'content-type': 'application/octet-stream' });
@@ -64,27 +67,7 @@ describe('action', () => {
       process.env['RUNNER_TEMP'] = directory;
 
       const action = require('./action');
-      await expect(await action()).toEqual({ version: '0.1.2' });
-      await expect(scope.isDone()).toBeTruthy();
-      done()
-    });
-  });
-
-  test('installs configured version', (done) => {
-    const scope = nock('https://api.github.com')
-      .get('/repos/hashicorp/releases-api/releases/tags/v0.1.2')
-      .reply(200, mockRelease)
-      .get('/repos/hashicorp/releases-api/releases/assets/1')
-      .replyWithFile(200, path.resolve(__dirname, 'test.zip'), { 'content-type': 'application/octet-stream' });
-
-    fs.mkdtemp(path.join(os.tmpdir(), 'setup-hc-releases-'), async (err, directory) => {
-      if (err) throw err;
-
-      process.env['INPUT_VERSION'] = '0.1.2';
-      process.env['RUNNER_TEMP'] = directory;
-
-      const action = require('./action');
-      await expect(await action()).toEqual({ version: '0.1.2' });
+      await expect(await action()).toEqual({ version: latestVersion });
       await expect(scope.isDone()).toBeTruthy();
       done()
     });
@@ -92,9 +75,9 @@ describe('action', () => {
 
   test('retries transient errors', (done) => {
     const scope = nock('https://api.github.com')
-      .get('/repos/hashicorp/releases-api/releases/tags/v0.1.2')
+      .get('/repos/hashicorp/releases-api/releases/tags/v'+latestVersion)
       .reply(500, 'expected transient error')
-      .get('/repos/hashicorp/releases-api/releases/tags/v0.1.2')
+      .get('/repos/hashicorp/releases-api/releases/tags/v'+latestVersion)
       .reply(200, mockRelease)
       .get('/repos/hashicorp/releases-api/releases/assets/1')
       .replyWithFile(200, path.resolve(__dirname, 'test.zip'), { 'content-type': 'application/octet-stream' });
@@ -105,7 +88,7 @@ describe('action', () => {
       process.env['RUNNER_TEMP'] = directory;
 
       const action = require('./action');
-      await expect(await action()).toEqual({ version: '0.1.2' });
+      await expect(await action()).toEqual({ version: latestVersion });
       await expect(scope.isDone()).toBeTruthy();
       done()
     });
@@ -113,12 +96,12 @@ describe('action', () => {
 
   test('retries secondary rate limit errors', (done) => {
     const scope = nock('https://api.github.com')
-      .get('/repos/hashicorp/releases-api/releases/tags/v0.1.2')
+      .get('/repos/hashicorp/releases-api/releases/tags/v'+latestVersion)
       .reply(403, {
         message: "You have exceeded a secondary rate limit and have been temporarily blocked from content creation. Please retry your request again later.",
         documentation_url: "https://docs.github.com/rest/overview/resources-in-the-rest-api#secondary-rate-limits"
       })
-      .get('/repos/hashicorp/releases-api/releases/tags/v0.1.2')
+      .get('/repos/hashicorp/releases-api/releases/tags/v'+latestVersion)
       .reply(200, mockRelease)
       .get('/repos/hashicorp/releases-api/releases/assets/1')
       .replyWithFile(200, path.resolve(__dirname, 'test.zip'), { 'content-type': 'application/octet-stream' });
@@ -129,7 +112,7 @@ describe('action', () => {
       process.env['RUNNER_TEMP'] = directory;
 
       const action = require('./action');
-      await expect(await action()).toEqual({ version: '0.1.2' });
+      await expect(await action()).toEqual({ version: latestVersion });
       await expect(scope.isDone()).toBeTruthy();
       done()
     });
@@ -137,9 +120,9 @@ describe('action', () => {
 
   test('retries rate limit errors', (done) => {
     const scope = nock('https://api.github.com')
-      .get('/repos/hashicorp/releases-api/releases/tags/v0.1.2')
+      .get('/repos/hashicorp/releases-api/releases/tags/v'+latestVersion)
       .reply(429, 'expected rate limit error')
-      .get('/repos/hashicorp/releases-api/releases/tags/v0.1.2')
+      .get('/repos/hashicorp/releases-api/releases/tags/v'+latestVersion)
       .reply(200, mockRelease)
       .get('/repos/hashicorp/releases-api/releases/assets/1')
       .replyWithFile(200, path.resolve(__dirname, 'test.zip'), { 'content-type': 'application/octet-stream' });
@@ -150,7 +133,48 @@ describe('action', () => {
       process.env['RUNNER_TEMP'] = directory;
 
       const action = require('./action');
-      await expect(await action()).toEqual({ version: '0.1.2' });
+      await expect(await action()).toEqual({ version: latestVersion });
+      await expect(scope.isDone()).toBeTruthy();
+      done()
+    });
+  });
+});
+
+describe('action with configured version', () => {
+  beforeEach(() => {
+    process.env['INPUT_GITHUB-TOKEN'] = token;
+    delete process.env['INPUT_VERSION'];
+    process.env['INPUT_VERSION-CHECKSUM'] = mockDataChecksum;
+
+    const spyExecExec = jest.spyOn(exec, 'exec');
+    spyExecExec.mockImplementation((commandLine, args, options) => {
+      if (commandLine === 'hc-releases' && args.length === 1 && args[0] === 'version' && options !== undefined && options.listeners !== undefined) {
+        options.listeners.stdout(configuredVersion);
+      }
+
+      Promise.resolve();
+    });
+    const spyOsArch = jest.spyOn(os, 'arch');
+    spyOsArch.mockReturnValue('x64');
+    const spyOsPlatform = jest.spyOn(os, 'platform');
+    spyOsPlatform.mockReturnValue('linux');
+  });
+
+  test('installs configured version', (done) => {
+    const scope = nock('https://api.github.com')
+      .get('/repos/hashicorp/releases-api/releases/tags/v'+configuredVersion)
+      .reply(200, mockReleaseVersion)
+      .get('/repos/hashicorp/releases-api/releases/assets/1')
+      .replyWithFile(200, path.resolve(__dirname, 'test.zip'), { 'content-type': 'application/octet-stream' });
+
+    fs.mkdtemp(path.join(os.tmpdir(), 'setup-hc-releases-'), async (err, directory) => {
+      if (err) throw err;
+
+      process.env['INPUT_VERSION'] = configuredVersion;
+      process.env['RUNNER_TEMP'] = directory;
+
+      const action = require('./action');
+      await expect(await action()).toEqual({ version: configuredVersion });
       await expect(scope.isDone()).toBeTruthy();
       done()
     });

--- a/hc-releases.js
+++ b/hc-releases.js
@@ -271,3 +271,4 @@ exports.releaseAssetChecksum = releaseAssetChecksum;
 exports.verifyReleaseAsset = verifyReleaseAsset;
 exports.version = version;
 exports.versionNumber = versionNumber;
+exports.checksums = checksums;

--- a/hc-releases.js
+++ b/hc-releases.js
@@ -134,7 +134,7 @@ const gitHubRepositoryOwner = 'hashicorp';
 const gitHubRepositoryRepo = 'releases-api';
 // This should be set to the version of hc-releases
 // we want to test with `npm run test`. Real API calls are made w/this version.
-const latestVersion = '0.1.2';
+const latestVersion = '0.1.14';
 const supportedGoPlatforms = {
   'darwin': ['amd64', 'arm64'],
   'linux': ['amd64']

--- a/hc-releases.live.test.js
+++ b/hc-releases.live.test.js
@@ -1,0 +1,82 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const { Octokit } = require("@octokit/rest");
+const core = require('@actions/core');
+
+const jsToGo = require('./js-to-go');
+const hcReleases = require('./hc-releases');
+
+describe('install live tool', () => {
+  removeTempdir = false;
+  directory = "";
+
+  beforeAll(() => { // setup tempdir
+    removeTempdir = false;
+    if (typeof process.env['RUNNER_TEMP'] === 'undefined') {
+      // RUNNER_TEMP is usually unset for local test runs.
+      // But the extractor assumes it's set.
+      process.env['RUNNER_TEMP'] = fs.mkdtempSync(path.join(os.tmpdir(), 'setup-hc-releases-'));
+      removeTempdir = true; // made our own tempdir, so remove it when we're done
+    }
+
+    directory = process.env['RUNNER_TEMP']
+  });
+
+  afterAll(() => { // cleanup tempdir
+    if (removeTempdir) {
+      console.log(`Removing tempdir we created: ${directory}`);
+      fs.rmSync(directory, { recursive: true });
+    }
+  });
+
+  test.each([
+    ['darwin', 'amd64'],
+    ['darwin', 'arm64'],
+    ['linux', 'amd64']
+  ])('%s/%s', async (goOperatingSystem, goArchitecture) => {
+    try {
+      // Support core.getInput for CI runs
+      // Also GITHUB_TOKEN which is simpler for local runs and overrides the input-format variable.
+      if (typeof process.env['GITHUB_TOKEN'] !== 'undefined') {
+        process.env['INPUT_GITHUB-TOKEN'] = process.env['GITHUB_TOKEN'];
+      }
+      const githubToken = core.getInput('github-token');
+      if (githubToken == '') {
+        throw 'No auth token set; consider setting GITHUB_TOKEN.';
+      }
+
+      const version = hcReleases.latestVersion;
+
+      // Ensure an expected checksum is defined before fetching the metadata or asset.
+      const checksum = hcReleases.releaseAssetChecksum(version, goOperatingSystem, goArchitecture);
+      if (typeof checksum === 'undefined') {
+        throw `No checksum known for v${version} on ${goOperatingSystem} / ${goArchitecture}`;
+      }
+
+      const client = new Octokit({
+        auth: githubToken,
+        log: console,
+      });
+
+      const releaseAsset = await hcReleases.getReleaseAsset(client, version, goOperatingSystem, goArchitecture);
+
+      const downloadPath = await hcReleases.downloadReleaseAsset(client, releaseAsset, directory);
+      await hcReleases.verifyReleaseAsset(client, downloadPath, checksum);
+      const binPath = await hcReleases.extractReleaseAsset(client, downloadPath);
+
+      // If the current os/arch matches the runner, go ahead and verify that the
+      // binary runs and reports the version we expect.
+      if (jsToGo.architecture() == goArchitecture && jsToGo.operatingSystem() == goOperatingSystem) {
+        core.addPath(binPath);
+        const installedVersion = await hcReleases.versionNumber();
+        client.log.debug(`installed version ${installedVersion}`);
+      }
+    } catch (err) {
+      // Retain tempdir for inspection after failures
+      removeTempdir = false;
+      throw err;
+    }
+  });
+});


### PR DESCRIPTION
Two main updates:
  * Previously, updating [latestVersion](https://github.com/hashicorp/setup-hc-releases/blob/bshore/releng-3-update-test-suite/hc-releases.js#L137) would break tests because they hardcoded version strings but the code under test used `latestVersion` by default
  * Add a live test (pre-existing tests use mocks) to validate the `latestVersion` build for each supported os/arch
     * fetch release metadata by version tag
     * download assets
     * verify checksums
     * extract assets from archives
     * run binary to extract embedded version string (only if runner os/arch match asset os/arch)

Test run [here](https://github.com/hashicorp/setup-hc-releases/actions/runs/3716653993/jobs/6303218121) (using temporary workflow tweak to trigger on feature branch).