### PR TITLE
Remove extant downloaded assets before download

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -84,3 +84,10 @@ jobs:
           echo "Incorrect hc-releases found (wrong version installed?  target version not first in PATH?)" 1>&2
           exit 1
         fi
+
+    # test that a single job can call the action multiple times
+    - name: Install hc-releases again
+      uses: ./
+      with:
+        github-token: ${{ inputs.github-token || secrets.TOKEN_DOWNLOAD_RELAPI }}
+        version: ${{ matrix.version }}

--- a/scripts/setup-hc-releases.sh
+++ b/scripts/setup-hc-releases.sh
@@ -55,6 +55,7 @@ sums_name="hc-releases_${version}_SHA256SUMS"
 echo "Installing release $version"
 
 # download
+/bin/rm -vf "$sums_name" "hc-releases_${version}_${pattern}" # remove in case they already exist from previous invocation
 gh release download --repo=hashicorp/releases-api "$tag" --pattern "$sums_name"
 gh release download --repo=hashicorp/releases-api "$tag" --pattern "*$pattern"
 # verify checksum


### PR DESCRIPTION
If actions/setup-hc-releases is run multiple times in a single job, the asset and checksums file will still be present and cause subsequent invocations of actions/setup-hc-releases to fail.

The `gh` option `--clobber` is not available on all runners, so explicitly remove the files instead.

Failed [workflow](https://github.com/hashicorp/vault-plugin-release/actions/runs/5017874908/jobs/8996560301) in which `actions-hc-releases-create-metadata` calls `setup-hc-releases` and a later step in the same job calls `setup-hc-releases` directly.