### PR TITLE
Install the latest release by default.

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -12,7 +12,7 @@ jobs:
   actionlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
       - name: "Check workflow files"
         uses: docker://docker.mirror.hashicorp.services/rhysd/actionlint:latest
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,13 +49,6 @@ jobs:
         run_quiet apt install --yes gh
         gh --version
 
-        # Install latest yq
-        BINARY=yq_linux_amd64
-        VERSION="$(gh --repo=https://github.com/mikefarah/yq release list |awk '$2 == "Latest" { print $3 }')"
-        gh --repo=https://github.com/mikefarah/yq release download "$VERSION" --clobber --output /usr/bin/yq --pattern "$BINARY"
-        /bin/chmod 755 /usr/bin/yq
-        yq --version
-
     - name: Install hc-releases
       uses: ./
       id: install
@@ -64,6 +57,8 @@ jobs:
         version: ${{ matrix.version }}
 
     - name: Test reported version
+      env:
+        GH_TOKEN: ${{ inputs.github-token || secrets.TOKEN_DOWNLOAD_RELAPI }}
       run: |
         got_ver="${{ steps.install.outputs.version }}"
         if [ -z "$got_ver" ]; then
@@ -72,8 +67,9 @@ jobs:
         fi
 
         exp_ver="${{ matrix.version }}"
-        if [ -z "$exp_ver" ]; then # default version according to action.yml
-          exp_ver="$(yq eval .inputs.version.default action.yml)"
+        if [ -z "$exp_ver" ]; then # default version, same method used by action.yml
+          echo "Identifying latest release..."
+          exp_ver="$(gh release list --repo=hashicorp/releases-api | awk '$2 == "Latest" { print $3 }')"
         fi
         if [ -z "$exp_ver" ]; then
           echo "Failed to determine expected version of hc-releases" 1>&2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
           - '${{ inputs.version }}'
           - '0.1.14' # need not be the most recent
     steps:
-    - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+    - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
 
     - name: "Install tools (only for running locally via act)"
       if: env.CI == 'true' && env.ACT == 'true'

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ jobs:
 | Input              | Description                                               | Default                |
 | ------------------ | --------------------------------------------------------- | ---------------------- |
 | `github-token`     | GitHub token with release asset access to `hc-releases`.  |                        |
-| `version`          | Version of `hc-releases` to install.                      | `v0.1.15`              |
+| `version`          | Version of `hc-releases` to install.                      | Latest release         |
 
 ### Outputs
 
@@ -42,14 +42,10 @@ act --container-architecture=linux/amd64 --input github-token=$(gh auth token) w
 The default version is set to avoid failed workflows if a broken `hc-releases` is published
 but can be passed explicitly for testing.
 
-### Supporting a new version of hc-releases
+### Creating a Release
 
-1. Clone this repo
-1. Update the default release version of `hc-releases`
-   * [README](https://github.com/hashicorp/setup-hc-releases/blob/main/README.md) chart
-   * Input `version` in [action.yml](https://github.com/hashicorp/setup-hc-releases/blob/main/action.yml#L18)
-1. Commit your changes, open a PR, get it reviewed, and merge to `main`.
-1. Checkout the `main` branch and pull the latest changes.
+After your PR is merged to the default branch, `main`:
+1. Update locally: `git checkout main && git pull`
 1. Create a new tag for the release, e.g. `v2.0.1` with `git tag v2.0.1 && git push origin v2.0.1`.
-1. Delete the major version tag, e.g. `git tag -d v2 && git push origin :refs/tags/v2`
-1. Create a new major version tag, e.g. `git tag v2 && git push origin v2`
+1. Update the major version tag locally, e.g. `git tag -d v2 && git tag v2`
+1. Update the tag upstream, e.g. `git push origin :refs/tags/v2 && git push origin v2`

--- a/action.yml
+++ b/action.yml
@@ -15,8 +15,8 @@ inputs:
     description: "GitHub token with release asset access to hc-releases."
     required: true
   version:
-    description: "Version of hc-releases to install, e.g. v0.1.10."
-    default: "v0.1.15"
+    description: "Version of hc-releases to install, e.g. v0.1.10. (Defaults to latest release)"
+    default: ""
   install-dir:
     description: "Where the tool will be installed; this directory will be added to GITHUB_PATH."
     default: "$HOME/bin"


### PR DESCRIPTION
This adds support for hc-releases v0.1.16 indirectly by always installing the most recent release.