### PR TITLE
Clean up downloaded assets after verification and install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
-# v3.0.1
+# v2.1.3
 
 BUG FIXES
 
 - Remove downloaded hc-release assets after verification and install to prevent dirty workspace directory for subsequent actions
 
-# v3.0.0
+# v2.0.0
 
 NOTES
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v3.0.1
+
+BUG FIXES
+
+- Remove downloaded hc-release assets after verification and install to prevent dirty workspace directory for subsequent actions
+
 # v3.0.0
 
 NOTES

--- a/scripts/setup-hc-releases.sh
+++ b/scripts/setup-hc-releases.sh
@@ -55,6 +55,7 @@ sums_name="hc-releases_${version}_SHA256SUMS"
 echo "Installing release $version"
 
 # download
+/bin/rm -vf "$sums_name" "hc-releases_${version}_${pattern}" # remove in case they already exist from previous invocation
 gh release download --repo=hashicorp/releases-api "$tag" --pattern "$sums_name"
 gh release download --repo=hashicorp/releases-api "$tag" --pattern "*$pattern"
 # verify checksum

--- a/scripts/setup-hc-releases.sh
+++ b/scripts/setup-hc-releases.sh
@@ -55,7 +55,6 @@ sums_name="hc-releases_${version}_SHA256SUMS"
 echo "Installing release $version"
 
 # download
-/bin/rm -vf "$sums_name" "hc-releases_${version}_${pattern}" # remove in case they already exist from previous invocation
 gh release download --repo=hashicorp/releases-api "$tag" --pattern "$sums_name"
 gh release download --repo=hashicorp/releases-api "$tag" --pattern "*$pattern"
 # verify checksum
@@ -66,6 +65,9 @@ mkdir -p "$DEST_DIR"
 run_quiet unzip -o -d "$DEST_DIR" "hc-releases_${version}_$pattern"
 chmod 755 "${DEST_DIR}/hc-releases"
 echo "$DEST_DIR" >> "$GITHUB_PATH"
+
+# clean up downloads
+/bin/rm -vf "$sums_name" "hc-releases_${version}_${pattern}"
 
 # report version installed
 V="$("${DEST_DIR}/hc-releases" version)"


### PR DESCRIPTION
Downstream actions, such as `goreleaser/goreleaser-action` expect the workspace directory to be clean, otherwise an error is thrown:

```
  • starting release...
  • loading                                          path=.goreleaser.yml
  • loading environment variables
    • using token from $GITHUB_TOKEN
  • getting and validating git state
    • git state                                      commit=ae346ceb6430b05e78d73a47b3975658f43ffa50 branch=HEAD current_tag=v2.4.2 previous_tag=v2.4.1 dirty=true
  ⨯ release failed after 0s                  error=git is in a dirty state
Please check in your pipeline what can be changing the following files:
?? hc-releases_0.1.15_SHA256SUMS
?? hc-releases_0.1.15_linux_amd64.zip

Learn more at https://goreleaser.com/errors/dirty
```